### PR TITLE
Add included_materials config option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "java"
 apply plugin: "maven"
 
-version = "2.3.1"
+version = "2.4.0"
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,18 @@ version = "2.3.1"
 
 repositories {
     mavenCentral()
-    maven { url "https://hub.spigotmc.org/nexus/content/repositories/snapshots/" }
+
+    maven {
+        url "https://hub.spigotmc.org/nexus/content/repositories/snapshots/"
+        content {
+            includeGroup 'org.bukkit'
+            includeGroup 'org.spigotmc'
+        }
+    }
+    maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
     mavenLocal()
 }
 
 dependencies {
-    compileOnly "org.spigotmc:spigot-api:1.14.4-R0.1-SNAPSHOT"
-    compileOnly "org.spigotmc:spigot:1.14.4-R0.1-SNAPSHOT"
+    compileOnly 'org.spigotmc:spigot:1.14.4-R0.1-SNAPSHOT'
 }

--- a/src/main/java/net/starlegacy/explosionregen/ExplosionListener.java
+++ b/src/main/java/net/starlegacy/explosionregen/ExplosionListener.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 class ExplosionListener implements Listener {
     private ExplosionRegenPlugin plugin;
@@ -48,11 +49,18 @@ class ExplosionListener implements Listener {
 
         List<ExplodedBlockData> explodedBlockDataList = new LinkedList<>();
 
+        Settings settings = plugin.getSettings();
+        Set<Material> includedMaterials = settings.getIncludedMaterials();
         for (Iterator<Block> iterator = list.iterator(); iterator.hasNext(); ) {
             Block block = iterator.next();
             BlockData blockData = block.getBlockData();
+            Material material = blockData.getMaterial();
 
-            if (plugin.getSettings().getIgnoredMaterials().contains(blockData.getMaterial())) {
+            if (settings.getIgnoredMaterials().contains(material)) {
+                continue;
+            }
+
+            if (!includedMaterials.isEmpty() && !includedMaterials.contains(material)) {
                 continue;
             }
 

--- a/src/main/java/net/starlegacy/explosionregen/Settings.java
+++ b/src/main/java/net/starlegacy/explosionregen/Settings.java
@@ -28,6 +28,10 @@ class Settings {
      * Types of blocks to not regenerate
      */
     private Set<Material> ignoredMaterials;
+    /**
+     * Types of blocks to regenerate. When empty, include all blocks
+     */
+    private Set<Material> includedMaterials;
 
     Settings(FileConfiguration config) {
         regenDelay = config.getDouble("regen_delay", 5.0);
@@ -40,6 +44,10 @@ class Settings {
                 .map(this::parseMaterial)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
+        includedMaterials = config.getStringList("included_materials").stream()
+                .map(this::parseMaterial)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
     }
 
     void save(FileConfiguration config) {
@@ -47,6 +55,7 @@ class Settings {
         config.set("placement_intensity", placementIntensity);
         config.set("ignored_entities", ignoredEntities.stream().map(Enum::name).collect(Collectors.toList()));
         config.set("ignored_materials", ignoredMaterials.stream().map(Enum::name).collect(Collectors.toList()));
+        config.set("included_materials", ignoredMaterials.stream().map(Enum::name).collect(Collectors.toList()));
     }
 
     private EntityType parseEntityType(String string) {
@@ -88,5 +97,9 @@ class Settings {
 
     public Set<Material> getIgnoredMaterials() {
         return ignoredMaterials;
+    }
+
+    public Set<Material> getIncludedMaterials() {
+        return includedMaterials;
     }
 }

--- a/src/main/java/net/starlegacy/explosionregen/Settings.java
+++ b/src/main/java/net/starlegacy/explosionregen/Settings.java
@@ -55,7 +55,7 @@ class Settings {
         config.set("placement_intensity", placementIntensity);
         config.set("ignored_entities", ignoredEntities.stream().map(Enum::name).collect(Collectors.toList()));
         config.set("ignored_materials", ignoredMaterials.stream().map(Enum::name).collect(Collectors.toList()));
-        config.set("included_materials", ignoredMaterials.stream().map(Enum::name).collect(Collectors.toList()));
+        config.set("included_materials", includedMaterials.stream().map(Enum::name).collect(Collectors.toList()));
     }
 
     private EntityType parseEntityType(String string) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,11 +6,17 @@ regen_delay: 5.0
 placement_intensity: 5
 
 # Blocks blown up by these entities will not be affected by this plugin
-# For a complete list of entity types, see https://papermc.io/javadocs/org/bukkit/entity/EntityType.html
+# For a complete list of entity types, see https://papermc.io/javadocs/paper/1.14/org/bukkit/entity/EntityType.html
 ignored_entities:
 # - PRIMED_TNT
 
 # Blocks with these materials which are blown up will be ignored
-# For a complete list of materials, see https://papermc.io/javadocs/org/bukkit/Material.html
+# For a complete list of materials, see https://papermc.io/javadocs/paper/1.14/org/bukkit/Material.html
 ignored_materials:
 # - TNT
+
+# Only blocks with these materials which are blown up will be regenerated.
+# When this list is empty, all blocks will be.
+# For a complete list of materials, see https://papermc.io/javadocs/paper/1.14/org/bukkit/Material.html
+included_materials:
+# - GRASS

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: ExplosionRegen
-version: 2.3.1
+version: 2.4.0
 main: net.starlegacy.explosionregen.ExplosionRegenPlugin
 authors: ["MicleBrick"]
 api-version: 1.14


### PR DESCRIPTION
This allows you to specify the *only* materials that get regenerated. For my server, I only want mob damage done to the terrain to be regenerated, so that the area around the spawn does not look like a battlefield, without resorting to disabling creeper damage.

This setting gets ignored if it's empty, i.e. leaving it empty will include all materials.

Example config:
```yaml
# Time in minutes after exploding blocks should regenerate
regen_delay: 5.0
placement_intensity: 5.0
ignored_entities:
- PRIMED_TNT
ignored_materials: []
included_materials:
- COARSE_DIRT
- MYCELIUM
- SAND
- CLAY
- DIRT
- GRASS_BLOCK
```

