### PR TITLE
Add Block Placement based on Distance 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,10 @@ gradle-app.setting
 
 
 # End of https://www.gitignore.io/api/gradle,kotlin,intellij
+
+# VS Code
+.vscode/*
+bin/*.yml
+.classpath
+.project
+.settings/*

--- a/src/main/java/net/starlegacy/explosionregen/ExplosionListener.java
+++ b/src/main/java/net/starlegacy/explosionregen/ExplosionListener.java
@@ -2,6 +2,7 @@ package net.starlegacy.explosionregen;
 
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.DoubleChest;
@@ -20,6 +21,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.lang.Math;
 
 class ExplosionListener implements Listener {
     private ExplosionRegenPlugin plugin;
@@ -34,20 +36,24 @@ class ExplosionListener implements Listener {
             return;
         }
 
-        processBlockList(event.getEntity().getWorld(), event.blockList());
+        processBlockList(event.getEntity().getWorld(), event.getLocation(), event.blockList());
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     void onBlockExplode(BlockExplodeEvent event) {
-        processBlockList(event.getBlock().getWorld(), event.blockList());
+        processBlockList(event.getBlock().getWorld(), event.getBlock().getLocation(), event.blockList());
     }
 
-    private void processBlockList(World world, List<Block> list) {
+    private void processBlockList(World world, Location explosionLocation, List<Block> list) {
         if (list.isEmpty()) {
             return;
         }
 
         List<ExplodedBlockData> explodedBlockDataList = new LinkedList<>();
+
+        double eX = explosionLocation.getX();
+        double eY = explosionLocation.getY();
+        double eZ = explosionLocation.getZ();
 
         Settings settings = plugin.getSettings();
         Set<Material> includedMaterials = settings.getIncludedMaterials();
@@ -70,8 +76,11 @@ class ExplosionListener implements Listener {
             int y = block.getY();
             int z = block.getZ();
 
+            double distance = Math.abs(eX - x) + Math.abs(eY - y) + Math.abs(eZ - z);
+
             long now = System.currentTimeMillis();
-            ExplodedBlockData explodedBlockData = new ExplodedBlockData(x, y, z, now, blockData, tileEntity);
+            long offset = Math.round((16 - distance) * plugin.getSettings().getDistanceDelay() * 1000);
+            ExplodedBlockData explodedBlockData = new ExplodedBlockData(x, y, z, now + offset, blockData, tileEntity);
             explodedBlockDataList.add(explodedBlockData);
             iterator.remove();
 

--- a/src/main/java/net/starlegacy/explosionregen/Settings.java
+++ b/src/main/java/net/starlegacy/explosionregen/Settings.java
@@ -17,6 +17,10 @@ class Settings {
      */
     private double regenDelay;
     /**
+     * Time in seconds of additional delay for each block away (taxicab distance)
+     */
+    private double distanceDelay;
+    /**
      * Maximum time in milliseconds that should be spent per tick regenerating exploded blocks
      */
     private double placementIntensity;
@@ -35,6 +39,7 @@ class Settings {
 
     Settings(FileConfiguration config) {
         regenDelay = config.getDouble("regen_delay", 5.0);
+        distanceDelay = config.getDouble("distance_delay", 2.5);
         placementIntensity = config.getDouble("placement_intensity", 5.0);
         ignoredEntities = config.getStringList("ignored_entities").stream()
                 .map(this::parseEntityType)
@@ -52,6 +57,7 @@ class Settings {
 
     void save(FileConfiguration config) {
         config.set("regen_delay", regenDelay);
+        config.set("regen_delay", distanceDelay);
         config.set("placement_intensity", placementIntensity);
         config.set("ignored_entities", ignoredEntities.stream().map(Enum::name).collect(Collectors.toList()));
         config.set("ignored_materials", ignoredMaterials.stream().map(Enum::name).collect(Collectors.toList()));
@@ -85,6 +91,10 @@ class Settings {
 
     public double getRegenDelay() {
         return regenDelay;
+    }
+
+    public double getDistanceDelay() {
+        return distanceDelay;
     }
 
     public double getPlacementIntensity() {


### PR DESCRIPTION
This adds a function to place blocks based on distance. Distance is measured using taxicab distance (xDistance + yDistance + zDistance). Blocks at distance 16 are placed after `regenDelay` minutes, while blocks closer or farther are adjusted by `distance * distanceDelay` seconds. This fixes #1.